### PR TITLE
Reset functionality + correctly moving map

### DIFF
--- a/src/visual/vis_button.py
+++ b/src/visual/vis_button.py
@@ -18,7 +18,7 @@ class vis_button(pg.sprite.Sprite):
         if font is None:
             font = pg.freetype.SysFont('Comic Sans MS', 16)
         self.font = font
-        self.textsurface, _ = font.render(text, (0, 0, 0))
+        self.textsurface, _ = font.render(text, (1, 1, 1))
         self.image.blit(self.textsurface, (10, 25))
 
     def local_coords(self, point):

--- a/src/visual/vis_frame.py
+++ b/src/visual/vis_frame.py
@@ -30,4 +30,15 @@ class vis_frame(pg.sprite.Sprite):
         self.map.set_moving(False)
 
     def check_motion(self, rel):
-        self.map.move(rel)
+        if not ((rel[0] > 0 and self.map.get_cells()[0][0].vis_cell.rect.center[0] > self.rect.center[0]) or
+                (rel[1] > 0 and self.map.get_cells()[0][0].vis_cell.rect.center[1] > self.rect.center[1]) or
+
+                (rel[0] > 0 and self.map.get_cells()[-1][0].vis_cell.rect.center[0] > self.rect.center[0]) or
+                (rel[1] < 0 and self.map.get_cells()[-1][0].vis_cell.rect.center[1] < self.rect.center[1]) or
+
+                (rel[0] < 0 and self.map.get_cells()[0][-1].vis_cell.rect.center[0] < self.rect.center[0]) or
+                (rel[1] > 0 and self.map.get_cells()[0][-1].vis_cell.rect.center[1] > self.rect.center[1]) or
+
+                (rel[0] < 0 and self.map.get_cells()[-1][-1].vis_cell.rect.center[0] < self.rect.center[0]) or
+                (rel[1] < 0 and self.map.get_cells()[-1][-1].vis_cell.rect.center[1] < self.rect.center[1])):
+            self.map.move(rel)

--- a/src/visual/vis_map.py
+++ b/src/visual/vis_map.py
@@ -94,3 +94,74 @@ class vis_map:
     def in_bounds(self, cell_x, cell_y):
         return (0 <= cell_x < len(self.cells)
                 and 0 <= cell_y < len(self.cells[cell_x]))
+
+import pygame
+import os
+from src.country_stat import Country_stat
+
+WHITE = (255, 255, 255)
+BLACK = (0, 0, 0)
+RED = (255, 0, 0)
+GREEN = (0, 255, 0)
+BLUE = (0, 0, 255)
+
+def generate_map(x: int, y: int, game_folder: str) -> vis_map:
+    cell_img = pygame.image.load(os.path.join(game_folder, 'res/hex1-res2.png')).convert()
+
+    gamemap = vis_map()
+    gamemap.set_size(x, y, cell_img)
+    gamemap.gen_terrain()
+
+    red_stat = Country_stat(RED)
+    blue_stat = Country_stat(BLUE)
+
+    red_capital_coords = (random.randint(1, x - 2), random.randint(1, y - 2))
+    blue_capital_coords = (random.randint(1, x - 2), random.randint(1, y - 2))
+    while -2 <= red_capital_coords[0] - blue_capital_coords[0] <= 2 and -2 <= red_capital_coords[1] - blue_capital_coords[1] <= 2:
+        blue_capital_coords = (random.randint(0, x - 1), random.randint(1, y - 2))
+    
+    red_stat.set_capital(red_capital_coords, gamemap)
+    blue_stat.set_capital(blue_capital_coords, gamemap)
+
+    red_stat.gen_unit_loc(3, 1, gamemap)
+    blue_stat.gen_unit_loc(3, 1, gamemap)
+
+# Water generation phase
+    banned_cells = set()
+    banned_cells.add(red_stat.get_capital())
+    banned_cells.add(blue_stat.get_capital())
+    for unit in red_stat.get_units():
+        banned_cells.add(unit.get_cell())
+    for unit in blue_stat.get_units():
+        banned_cells.add(unit.get_cell())
+    gamemap.gen_water(banned_cells)
+
+    townhall_img = pygame.image.load(os.path.join
+                                     (game_folder, 'res/townhall.png')).convert()
+    for building in red_stat.get_buildings():
+        building.add_vis_unit(townhall_img)
+        building_cell = building.get_cell()
+        gamemap.get_cells()[building_cell[0]][building_cell[1]].\
+            vis_cell.set_unit(building.vis_unit)
+        building.vis_unit.set_immovable(True)
+    for building in blue_stat.get_buildings():
+        building.add_vis_unit(townhall_img)
+        building_cell = building.get_cell()
+        gamemap.get_cells()[building_cell[0]][building_cell[1]].\
+            vis_cell.set_unit(building.vis_unit)
+        building.vis_unit.set_immovable(True)
+
+    spearman_img = pygame.image.load(os.path.join
+                                     (game_folder, 'res/spearman.png')).convert()
+    for unit in red_stat.get_units():
+        unit.add_vis_unit(spearman_img)
+        unit_cell = unit.get_cell()
+        gamemap.get_cells()[unit_cell[0]][unit_cell[1]].\
+            vis_cell.set_unit(unit.vis_unit)
+    for unit in blue_stat.get_units():
+        unit.add_vis_unit(spearman_img)
+        unit_cell = unit.get_cell()
+        gamemap.get_cells()[unit_cell[0]][unit_cell[1]].\
+            vis_cell.set_unit(unit.vis_unit)
+    return gamemap
+

--- a/tests/interface.py
+++ b/tests/interface.py
@@ -43,7 +43,7 @@ cell_img = pygame.image.load(os.path.join(game_folder, 'res/hex1-res2.png')).con
 cursor_img = pygame.image.load(os.path.join(game_folder, 'res/cursor1_rs2.png')).convert()
 
 gamemap = vis_map()
-gamemap.set_size(20, 7, cell_img)
+gamemap.set_size(30, 10, cell_img)
 gamemap.gen_terrain()
 
 cursor = vis_cursor(cursor_img)
@@ -157,8 +157,16 @@ while running:
     all_sprites.update()
 
     screen.fill(BLACK)
-    all_sprites.draw(screen)
     #reset_map_button.draw_text()
+    all_sprites.remove_sprites_of_layer(1)
+    all_sprites.remove_sprites_of_layer(2)
+    for line in gamemap.get_cells():
+        for cell in line:
+            if global_frame.rect.contains(cell.vis_cell.rect):
+                all_sprites.add(cell.vis_cell)
+                if cell.vis_cell.unit is not None:
+                    all_sprites.add(cell.vis_cell.unit)
+    all_sprites.draw(screen)
     pygame.display.flip()
 
 pygame.quit()

--- a/tests/interface.py
+++ b/tests/interface.py
@@ -157,7 +157,6 @@ while running:
     all_sprites.update()
 
     screen.fill(BLACK)
-    #reset_map_button.draw_text()
     all_sprites.remove_sprites_of_layer(1)
     all_sprites.remove_sprites_of_layer(2)
     for line in gamemap.get_cells():

--- a/tests/interface.py
+++ b/tests/interface.py
@@ -8,7 +8,7 @@ from src.country_stat import Country_stat
 from src.unit import Unit
 from src.visual.vis_cursor import vis_cursor
 from src.visual.vis_cell import vis_cell
-from src.visual.vis_map import vis_map
+from src.visual.vis_map import vis_map, generate_map
 from src.visual.vis_button import vis_button
 from src.visual.vis_frame import vis_frame
 from src.visual.vis_unit import vis_unit
@@ -29,62 +29,10 @@ def exit():
     global running
     running = False
 
-def generate_map(x: int, y: int) -> vis_map:
-    gamemap = vis_map()
-    gamemap.set_size(x, y, cell_img)
-    gamemap.gen_terrain()
-
-    red_stat = Country_stat(RED)
-    blue_stat = Country_stat(BLUE)
-    red_capital_coords = ()
-    red_stat.set_capital((1, 1), gamemap)
-    blue_stat.set_capital((5, 5), gamemap)
-
-    red_stat.gen_unit_loc(3, 1, gamemap)
-    blue_stat.gen_unit_loc(3, 1, gamemap)
-
-# Water generation phase
-    banned_cells = set()
-    banned_cells.add(red_stat.get_capital())
-    banned_cells.add(blue_stat.get_capital())
-    for unit in red_stat.get_units():
-        banned_cells.add(unit.get_cell())
-    for unit in blue_stat.get_units():
-        banned_cells.add(unit.get_cell())
-    gamemap.gen_water(banned_cells)
-
-    townhall_img = pygame.image.load(os.path.join
-                                     (game_folder, 'res/townhall.png')).convert()
-    for building in red_stat.get_buildings():
-        building.add_vis_unit(townhall_img)
-        building_cell = building.get_cell()
-        gamemap.get_cells()[building_cell[0]][building_cell[1]].\
-            vis_cell.set_unit(building.vis_unit)
-        building.vis_unit.set_immovable(True)
-    for building in blue_stat.get_buildings():
-        building.add_vis_unit(townhall_img)
-        building_cell = building.get_cell()
-        gamemap.get_cells()[building_cell[0]][building_cell[1]].\
-            vis_cell.set_unit(building.vis_unit)
-        building.vis_unit.set_immovable(True)
-
-    spearman_img = pygame.image.load(os.path.join
-                                     (game_folder, 'res/spearman.png')).convert()
-    for unit in red_stat.get_units():
-        unit.add_vis_unit(spearman_img)
-        unit_cell = unit.get_cell()
-        gamemap.get_cells()[unit_cell[0]][unit_cell[1]].\
-            vis_cell.set_unit(unit.vis_unit)
-    for unit in blue_stat.get_units():
-        unit.add_vis_unit(spearman_img)
-        unit_cell = unit.get_cell()
-        gamemap.get_cells()[unit_cell[0]][unit_cell[1]].\
-            vis_cell.set_unit(unit.vis_unit)
-    return gamemap
-
 def reset_map():
     global gamemap
-    gamemap = generate_map(30, 10)
+    global game_folder
+    gamemap = generate_map(30, 10, game_folder)
     global global_frame
     global_frame.map = gamemap
 
@@ -98,14 +46,13 @@ clock = pygame.time.Clock()
 
 all_sprites = pygame.sprite.LayeredUpdates()
 
-cell_img = pygame.image.load(os.path.join(game_folder, 'res/hex1-res2.png')).convert()
 cursor_img = pygame.image.load(os.path.join(game_folder, 'res/cursor1_rs2.png')).convert()
 
 cursor = vis_cursor(cursor_img)
 
 all_sprites.add(cursor)
 
-gamemap = generate_map(30, 10)
+gamemap = generate_map(30, 10, game_folder)
 
 button_img = pygame.image.load(os.path.join(game_folder, 'res/frame_button1.png')).convert()
 reset_map_button = vis_button(740, 50, 'Reset map', button_img)

--- a/tests/interface.py
+++ b/tests/interface.py
@@ -29,6 +29,65 @@ def exit():
     global running
     running = False
 
+def generate_map(x: int, y: int) -> vis_map:
+    gamemap = vis_map()
+    gamemap.set_size(x, y, cell_img)
+    gamemap.gen_terrain()
+
+    red_stat = Country_stat(RED)
+    blue_stat = Country_stat(BLUE)
+    red_capital_coords = ()
+    red_stat.set_capital((1, 1), gamemap)
+    blue_stat.set_capital((5, 5), gamemap)
+
+    red_stat.gen_unit_loc(3, 1, gamemap)
+    blue_stat.gen_unit_loc(3, 1, gamemap)
+
+# Water generation phase
+    banned_cells = set()
+    banned_cells.add(red_stat.get_capital())
+    banned_cells.add(blue_stat.get_capital())
+    for unit in red_stat.get_units():
+        banned_cells.add(unit.get_cell())
+    for unit in blue_stat.get_units():
+        banned_cells.add(unit.get_cell())
+    gamemap.gen_water(banned_cells)
+
+    townhall_img = pygame.image.load(os.path.join
+                                     (game_folder, 'res/townhall.png')).convert()
+    for building in red_stat.get_buildings():
+        building.add_vis_unit(townhall_img)
+        building_cell = building.get_cell()
+        gamemap.get_cells()[building_cell[0]][building_cell[1]].\
+            vis_cell.set_unit(building.vis_unit)
+        building.vis_unit.set_immovable(True)
+    for building in blue_stat.get_buildings():
+        building.add_vis_unit(townhall_img)
+        building_cell = building.get_cell()
+        gamemap.get_cells()[building_cell[0]][building_cell[1]].\
+            vis_cell.set_unit(building.vis_unit)
+        building.vis_unit.set_immovable(True)
+
+    spearman_img = pygame.image.load(os.path.join
+                                     (game_folder, 'res/spearman.png')).convert()
+    for unit in red_stat.get_units():
+        unit.add_vis_unit(spearman_img)
+        unit_cell = unit.get_cell()
+        gamemap.get_cells()[unit_cell[0]][unit_cell[1]].\
+            vis_cell.set_unit(unit.vis_unit)
+    for unit in blue_stat.get_units():
+        unit.add_vis_unit(spearman_img)
+        unit_cell = unit.get_cell()
+        gamemap.get_cells()[unit_cell[0]][unit_cell[1]].\
+            vis_cell.set_unit(unit.vis_unit)
+    return gamemap
+
+def reset_map():
+    global gamemap
+    gamemap = generate_map(30, 10)
+    global global_frame
+    global_frame.map = gamemap
+
 pygame.init()
 pygame.font.init()
 pygame.mixer.init()
@@ -42,74 +101,21 @@ all_sprites = pygame.sprite.LayeredUpdates()
 cell_img = pygame.image.load(os.path.join(game_folder, 'res/hex1-res2.png')).convert()
 cursor_img = pygame.image.load(os.path.join(game_folder, 'res/cursor1_rs2.png')).convert()
 
-gamemap = vis_map()
-gamemap.set_size(30, 10, cell_img)
-gamemap.gen_terrain()
-
 cursor = vis_cursor(cursor_img)
 
 all_sprites.add(cursor)
-for line in gamemap.get_cells():
-    for cell in line:
-        all_sprites.add(cell.vis_cell)
 
-red_stat = Country_stat(RED)
-blue_stat = Country_stat(BLUE)
-red_stat.set_capital((1, 1), gamemap)
-blue_stat.set_capital((5, 5), gamemap)
-
-red_stat.gen_unit_loc(3, 1, gamemap)
-blue_stat.gen_unit_loc(3, 1, gamemap)
-
-# Water generation phase
-banned_cells = set()
-banned_cells.add(red_stat.get_capital())
-banned_cells.add(blue_stat.get_capital())
-for unit in red_stat.get_units():
-    banned_cells.add(unit.get_cell())
-for unit in blue_stat.get_units():
-    banned_cells.add(unit.get_cell())
-gamemap.gen_water(banned_cells)
-
-townhall_img = pygame.image.load(os.path.join
-                                 (game_folder, 'res/townhall.png')).convert()
-for building in red_stat.get_buildings():
-    building.add_vis_unit(townhall_img)
-    building_cell = building.get_cell()
-    gamemap.get_cells()[building_cell[0]][building_cell[1]].\
-        vis_cell.set_unit(building.vis_unit)
-    building.vis_unit.set_immovable(True)
-    all_sprites.add(building.vis_unit)
-for building in blue_stat.get_buildings():
-    building.add_vis_unit(townhall_img)
-    building_cell = building.get_cell()
-    gamemap.get_cells()[building_cell[0]][building_cell[1]].\
-        vis_cell.set_unit(building.vis_unit)
-    building.vis_unit.set_immovable(True)
-    all_sprites.add(building.vis_unit)
-
-spearman_img = pygame.image.load(os.path.join
-                                 (game_folder, 'res/spearman.png')).convert()
-for unit in red_stat.get_units():
-    unit.add_vis_unit(spearman_img)
-    unit_cell = unit.get_cell()
-    gamemap.get_cells()[unit_cell[0]][unit_cell[1]].\
-        vis_cell.set_unit(unit.vis_unit)
-    all_sprites.add(unit.vis_unit)
-for unit in blue_stat.get_units():
-    unit.add_vis_unit(spearman_img)
-    unit_cell = unit.get_cell()
-    gamemap.get_cells()[unit_cell[0]][unit_cell[1]].\
-        vis_cell.set_unit(unit.vis_unit)
-    all_sprites.add(unit.vis_unit)
+gamemap = generate_map(30, 10)
 
 button_img = pygame.image.load(os.path.join(game_folder, 'res/frame_button1.png')).convert()
 reset_map_button = vis_button(740, 50, 'Reset map', button_img)
+reset_map_button.action = reset_map
 all_sprites.add(reset_map_button)
 
 button_img = pygame.image.load(os.path.join(game_folder, 'res/frame_button1.png')).convert()
 end_turn_button = vis_button(740, 180, 'End turn', button_img)
 all_sprites.add(end_turn_button)
+
 button_img = pygame.image.load(os.path.join(game_folder, 'res/frame_button1.png')).convert()
 red_score_button = vis_button(740, 245, 'Red Score', button_img)
 all_sprites.add(red_score_button)


### PR DESCRIPTION
- "Reset map" now regenerates game map
- Parts of game map that appear outside frame are cut off
- Now map can't move fully out of frame (stops whenever any corner crosses middle of frame)
- Text on buttons is now actually black and is not transparent
- Map generation is now a function and is located in src/visual/vis_map.py where it belongs
- Countries' capitals are generated randomly with some restrictions